### PR TITLE
Add GayTorrents spider with login and category browsing support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
+# ── Stage 1: build frontend ───────────────────────────────────────────────────
+FROM node:20-slim AS frontend-builder
+
+WORKDIR /frontend
+COPY frontend/package*.json ./
+RUN npm ci
+
+COPY frontend/ ./
+RUN npm run build
+
+# ── Stage 2: runtime ──────────────────────────────────────────────────────────
 FROM python:3.11.4-slim-bullseye
 LABEL authors="Chris"
 
@@ -8,13 +19,17 @@ ENV LANG="C.UTF-8" \
     UMASK=000
 
 RUN apt-get update -y \
-    && apt-get -y install nginx locales gosu
+    && apt-get -y install nginx locales gosu \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ./nginx/ /etc/nginx/conf.d/
 COPY . /app/
+# Replace pre-built dist (if any) with the freshly built one
+COPY --from=frontend-builder /frontend/dist /app/dist
 
 WORKDIR /app
-RUN pip install -r requirements.txt \
+RUN pip install --no-cache-dir -r requirements.txt \
     && chown -R www-data /app/dist \
     && locale-gen zh_CN.UTF-8 \
     && groupadd -r tissue -g 911 \

--- a/alembic/versions/a1b2c3d4e5f6_add_gaytorrents_site.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_gaytorrents_site.py
@@ -1,0 +1,29 @@
+"""add gaytorrents site
+
+Revision ID: a1b2c3d4e5f6
+Revises: 6c9f20f3c1ab
+Create Date: 2026-04-23 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '6c9f20f3c1ab'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+site_table = sa.table('site', sa.column('spider_key', sa.String), sa.column('priority', sa.Integer))
+
+
+def upgrade() -> None:
+    op.bulk_insert(site_table, [
+        {'spider_key': 'gaytorrents', 'priority': 5},
+    ])
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM site WHERE spider_key = 'gaytorrents'"))

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -19,6 +19,18 @@ def get_rankings(site_id: int, video_type: str, cycle: str, service=Depends(get_
     return service.get_ranking(site_id, video_type, cycle)
 
 
+@router.get('/cover')
+def get_cover(site_id: int, num: str, url: str, service=Depends(get_spider_service)):
+    spider = service.build_spider_by_site_id(site_id)
+    if not spider or not hasattr(spider, 'get_info'):
+        return R.ok({'cover': None})
+    try:
+        info = spider.get_info(num, url, include_downloads=False, include_previews=False)
+        return R.ok({'cover': info.cover})
+    except Exception:
+        return R.ok({'cover': None})
+
+
 @router.get('/detail')
 def get_detail(site_id: int, num: str, url: str, service=Depends(get_spider_service)):
     return service.get_detail(site_id, num, url)

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -5,8 +5,11 @@ import tailer
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
+from app.exception import BizException
+from app.schema import Setting
 from app.schema.r import R
 from app.service.spider import get_spider_service
+from app.utils.qbittorent import qbittorent
 
 router = APIRouter()
 
@@ -24,6 +27,27 @@ def get_detail(site_id: int, num: str, url: str, service=Depends(get_spider_serv
 @router.get('/actor')
 def get_actor(site_id: int, code: str, page: int = 1, service=Depends(get_spider_service)):
     return R.pages(service.get_actor(site_id, code, page))
+
+
+@router.post('/torrent-download')
+def download_torrent(site_id: int, torrent_id: str, service=Depends(get_spider_service)):
+    spider = service.build_spider_by_site_id(site_id)
+    if not spider or not hasattr(spider, 'download_torrent_file'):
+        raise BizException('该站点不支持种子下载')
+
+    torrent_data = spider.download_torrent_file(torrent_id)
+    if not torrent_data:
+        raise BizException('种子下载失败，请检查登录状态')
+
+    setting = Setting()
+    path = setting.download.download_path
+    category = setting.download.category or None
+
+    response = qbittorent.add_torrent_file(torrent_data, path, category)
+    if response.status_code != 200:
+        raise BizException('发送到下载器失败')
+
+    return R.ok()
 
 
 @router.get('/log')

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -15,8 +15,8 @@ router = APIRouter()
 
 
 @router.get('/ranking')
-def get_rankings(site_id: int, video_type: str, cycle: str, service=Depends(get_spider_service)):
-    return service.get_ranking(site_id, video_type, cycle)
+def get_rankings(site_id: int, video_type: str, cycle: str, pages: int = 1, service=Depends(get_spider_service)):
+    return service.get_ranking(site_id, video_type, cycle, pages=pages)
 
 
 @router.get('/cover')

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -2,8 +2,8 @@ import time
 from pathlib import Path
 
 import tailer
-from fastapi import APIRouter, Depends
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response, StreamingResponse
 
 from app.exception import BizException
 from app.schema import Setting
@@ -29,6 +29,24 @@ def get_cover(site_id: int, num: str, url: str, service=Depends(get_spider_servi
         return R.ok({'cover': info.cover})
     except Exception:
         return R.ok({'cover': None})
+
+
+@router.get('/proxy-image')
+def proxy_image(site_id: int, url: str, service=Depends(get_spider_service)):
+    """Fetch an image through the site's authenticated session and return the bytes."""
+    spider = service.build_spider_by_site_id(site_id)
+    if not spider:
+        raise HTTPException(status_code=404)
+    try:
+        resp = spider.session.get(url)
+        if not resp.ok:
+            raise HTTPException(status_code=404)
+        content_type = resp.headers.get('content-type', 'image/jpeg')
+        return Response(content=resp.content, media_type=content_type)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=404)
 
 
 @router.get('/detail')

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -21,28 +21,19 @@ def get_rankings(site_id: int, video_type: str, cycle: str, service=Depends(get_
 
 @router.get('/cover')
 def get_cover(site_id: int, num: str, url: str, service=Depends(get_spider_service)):
-    spider = service.build_spider_by_site_id(site_id)
-    if not spider or not hasattr(spider, 'get_info'):
-        return R.ok({'cover': None})
-    try:
-        info = spider.get_info(num, url, include_downloads=False, include_previews=False)
-        return R.ok({'cover': info.cover})
-    except Exception:
-        return R.ok({'cover': None})
-
-
-@router.get('/proxy-image')
-def proxy_image(site_id: int, url: str, service=Depends(get_spider_service)):
-    """Fetch an image through the site's authenticated session and return the bytes."""
+    """Fetch the first image from the torrent detail page and return the bytes directly."""
     spider = service.build_spider_by_site_id(site_id)
     if not spider:
         raise HTTPException(status_code=404)
     try:
-        resp = spider.session.get(url)
-        if not resp.ok:
+        info = spider.get_info(num, url, include_downloads=False, include_previews=False)
+        if not info.cover:
             raise HTTPException(status_code=404)
-        content_type = resp.headers.get('content-type', 'image/jpeg')
-        return Response(content=resp.content, media_type=content_type)
+        img_resp = spider.session.get(info.cover)
+        if not img_resp.ok:
+            raise HTTPException(status_code=404)
+        content_type = img_resp.headers.get('content-type', 'image/jpeg')
+        return Response(content=img_resp.content, media_type=content_type)
     except HTTPException:
         raise
     except Exception:

--- a/app/schema/site.py
+++ b/app/schema/site.py
@@ -9,6 +9,7 @@ class SpiderKey(StrEnum):
     JAVBUS = 'javbus'
     JAV321 = 'jav321'
     DMM = 'dmm'
+    GAYTORRENTS = 'gaytorrents'
 
 
 class SiteCapabilities(BaseModel):

--- a/app/schema/site.py
+++ b/app/schema/site.py
@@ -45,4 +45,4 @@ class LoginSubmit(BaseModel):
     authenticity_token: str
     username: str
     password: str
-    captcha: str
+    captcha: str = ''

--- a/app/service/spider.py
+++ b/app/service/spider.py
@@ -179,11 +179,11 @@ class SpiderService(BaseService):
 
         return meta
 
-    def get_ranking(self, site_id: int, video_type: str, cycle: str):
+    def get_ranking(self, site_id: int, video_type: str, cycle: str, pages: int = 1):
         spider = self.build_spider_by_site_id(site_id)
         if not spider or not spider.supports_ranking:
             return None
-        return spider.get_ranking(video_type, cycle)
+        return spider.get_ranking(video_type, cycle, pages=pages)
 
     def get_detail(self, site_id: int, num: str, url: str):
         spider = self.build_spider_by_site_id(site_id)

--- a/app/service/spider.py
+++ b/app/service/spider.py
@@ -14,7 +14,7 @@ from app.schema import SiteCapabilities, SpiderKey, VideoDetail
 from app.service.base import BaseService
 from app.utils import cache
 from app.utils.logger import logger
-from app.utils.spider import DmmSpider, Jav321Spider, JavBusSpider, JavDBSpider
+from app.utils.spider import DmmSpider, GayTorrentsSpider, Jav321Spider, JavBusSpider, JavDBSpider
 from app.utils.spider.spider import Spider
 from app.utils.spider.spider_exception import SpiderException
 
@@ -29,6 +29,7 @@ class SpiderService(BaseService):
         SpiderKey.JAVBUS: JavBusSpider,
         SpiderKey.JAV321: Jav321Spider,
         SpiderKey.DMM: DmmSpider,
+        SpiderKey.GAYTORRENTS: GayTorrentsSpider,
     }
 
     @staticmethod

--- a/app/utils/qbittorent.py
+++ b/app/utils/qbittorent.py
@@ -124,5 +124,38 @@ class QBittorent:
         self.remove_torrent_tags(torrent_hash, [nonce])
         return response
 
+    @auth
+    def add_torrent_file(self, torrent_data: bytes, path: str, category: str | None = None):
+        nonce = ''.join(random.sample('abcdefghijklmnopqrstuvwxyz', 5))
+        response = self.session.post(
+            urljoin(self.host, '/api/v2/torrents/add'),
+            data={'tags': nonce, 'savepath': path, 'category': category},
+            files={'torrents': ('upload.torrent', torrent_data, 'application/x-bittorrent')}
+        )
+        if response.status_code != 200:
+            return response
+
+        torrent_hash = ''
+        for _ in range(5):
+            time.sleep(1)
+            torrents = self.session.get(urljoin(self.host, '/api/v2/torrents/info'), params={
+                'tag': nonce
+            }).json()
+            if torrents:
+                torrent_hash = torrents[0]['hash']
+                response.hash = torrent_hash
+                break
+
+        if self.tracker_subscribe and torrent_hash:
+            trackers_text = requests.get(self.tracker_subscribe, timeout=10).text
+            trackers = '\n'.join(filter(lambda item: item, trackers_text.split("\n")))
+            self.session.post(urljoin(self.host, '/api/v2/torrents/addTrackers'), data={
+                'hash': torrent_hash,
+                'urls': trackers
+            })
+
+        self.remove_torrent_tags(torrent_hash, [nonce])
+        return response
+
 
 qbittorent = QBittorent()

--- a/app/utils/spider/__init__.py
+++ b/app/utils/spider/__init__.py
@@ -1,4 +1,5 @@
 from app.utils.spider.dmm import DmmSpider
+from app.utils.spider.gaytorrents import GayTorrentsSpider
 from app.utils.spider.jav321 import Jav321Spider
 from app.utils.spider.javbus import JavBusSpider
 from app.utils.spider.javdb import JavDBSpider

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -184,6 +184,27 @@ class GayTorrentsSpider(Spider):
         download.size = size
         return [download]
 
+    def download_torrent_file(self, torrent_id: str) -> bytes | None:
+        """Download the raw .torrent file bytes using the authenticated session."""
+        detail_url = urljoin(self.host, f'/torrentdetails.php?torrentid={torrent_id}')
+        response = self.session.get(detail_url)
+        if not response.ok:
+            return None
+        html = etree.HTML(response.content)
+        tokens = html.xpath("//form[@name='torrentform']//input[@name='securitytoken']/@value")
+        if not tokens:
+            return None
+        dl = self.session.post(urljoin(self.host, '/torrentdetails.php'), data={
+            'do': 'download',
+            'securitytoken': tokens[0],
+            'torrentid': torrent_id,
+            'download': 'as Torrent',
+        })
+        content_type = dl.headers.get('content-type', '')
+        if dl.ok and ('torrent' in content_type or 'octet-stream' in content_type or dl.content[:1] == b'd'):
+            return dl.content
+        return None
+
     def get_ranking(self, video_type: str, cycle: str):
         # video_type is the category path e.g. "porn/Asian" or "nonporn/Drama"
         url = urljoin(self.host, f'/torrentslist.php?type={video_type}')

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -205,15 +205,25 @@ class GayTorrentsSpider(Spider):
             return dl.content
         return None
 
-    def get_ranking(self, video_type: str, cycle: str):
+    def get_ranking(self, video_type: str, cycle: str, pages: int = 1):
         # video_type is the category path e.g. "porn/Asian" or "nonporn/Drama"
-        url = urljoin(self.host, f'/torrentslist.php?type={video_type}')
-        response = self.session.get(url)
-        if not response.ok:
-            return []
-
-        html = etree.HTML(response.content, parser=etree.HTMLParser(encoding='utf-8'))
-        return self._parse_listing(html)
+        result = []
+        seen_ids: set[str] = set()
+        pages = min(max(pages, 1), 20)  # clamp 1–20
+        for page in range(1, pages + 1):
+            url = urljoin(self.host, f'/torrentslist.php?type={video_type}&page={page}')
+            response = self.session.get(url)
+            if not response.ok:
+                break
+            html = etree.HTML(response.content, parser=etree.HTMLParser(encoding='utf-8'))
+            items = self._parse_listing(html)
+            new_items = [i for i in items if i.num not in seen_ids]
+            if not new_items:
+                break  # no new content — last page reached
+            for i in new_items:
+                seen_ids.add(i.num)
+            result.extend(new_items)
+        return result
 
     def _parse_listing(self, html):
         result = []

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -17,6 +17,11 @@ from app.utils.spider.spider import Session, Spider
 from app.utils.spider.spider_exception import SpiderException
 
 
+def _text(el) -> str:
+    """Extract all text from an lxml etree element recursively."""
+    return el.xpath('string()').strip()
+
+
 class GayTorrentsSpider(Spider):
     key = 'gaytorrents'
     name = 'GayTorrents'
@@ -94,32 +99,31 @@ class GayTorrentsSpider(Spider):
 
         html = etree.HTML(response.content, parser=etree.HTMLParser(encoding='utf-8'))
 
-        # Check we actually got a torrent page (requires login if not logged in)
         title_el = html.xpath("//h2[@id='file_name']")
         if not title_el:
             raise SpiderException('未找到种子详情，请检查登录状态')
 
         meta = VideoDetail()
         meta.num = num
-        meta.title = title_el[0].text_content().strip()
+        meta.title = _text(title_el[0])
 
         # Parse dt/dd info pairs
         dt_els = html.xpath("//dl[contains(@class,'userinfo_extra')]/dt")
         dd_els = html.xpath("//dl[contains(@class,'userinfo_extra')]/dd")
-        info = {dt.text_content().strip(): dd for dt, dd in zip(dt_els, dd_els)}
+        info = {_text(dt): dd for dt, dd in zip(dt_els, dd_els)}
 
         if 'Uploaded' in info:
             try:
                 meta.premiered = datetime.strptime(
-                    info['Uploaded'].text_content().strip(), '%H:%M %d-%b-%Y'
+                    _text(info['Uploaded']), '%H:%M %d-%b-%Y'
                 ).strftime('%Y-%m-%d')
             except ValueError:
-                meta.premiered = info['Uploaded'].text_content().strip()
+                meta.premiered = _text(info['Uploaded'])
 
         # Tags
         tag_els = html.xpath("//dd[@id='taglist']/a")
         if tag_els:
-            meta.tags = [el.text_content().strip() for el in tag_els if el.text_content().strip()]
+            meta.tags = [_text(el) for el in tag_els if _text(el)]
 
         # Category as studio
         cat_el = html.xpath("//dd[@id='category']//img/@title")
@@ -129,7 +133,7 @@ class GayTorrentsSpider(Spider):
         # Description / outline
         desc_el = html.xpath("//div[@id='description']")
         if desc_el:
-            meta.outline = desc_el[0].text_content().strip()
+            meta.outline = _text(desc_el[0])
 
         # Cover = first full-size preview image
         img_links = html.xpath("//div[@id='displayimages']/a/@href")
@@ -164,11 +168,11 @@ class GayTorrentsSpider(Spider):
             return []
 
         title_el = html.xpath("//h2[@id='file_name']")
-        name = title_el[0].text_content().strip() if title_el else 'Torrent'
+        name = _text(title_el[0]) if title_el else 'Torrent'
 
         size_dd = html.xpath("//dl[contains(@class,'userinfo_extra')]/dt[text()='Size']"
                              "/following-sibling::dd[1]")
-        size = size_dd[0].text_content().strip() if size_dd else None
+        size = _text(size_dd[0]) if size_dd else None
 
         download = VideoDownload(source=self.source_ref())
         download.url = page_url
@@ -196,7 +200,7 @@ class GayTorrentsSpider(Spider):
 
             a = name_li[0]
             href = a.get('href', '')
-            title = a.text_content().strip()
+            title = _text(a)
             if not href or not title:
                 continue
 
@@ -207,7 +211,7 @@ class GayTorrentsSpider(Spider):
             date_li = row.xpath(".//li[contains(@class,'Torrent-List-Date')]")
             publish_date = None
             if date_li:
-                date_str = date_li[0].text_content().strip()
+                date_str = _text(date_li[0])
                 try:
                     publish_date = datetime.strptime(date_str, '%H:%M %d-%b-%Y').date()
                 except ValueError:
@@ -216,7 +220,7 @@ class GayTorrentsSpider(Spider):
             seeds_li = row.xpath(".//li[contains(@class,'Torrent-List-Seeds')]")
             rank = None
             if seeds_li:
-                seeds_text = seeds_li[0].text_content().strip().rstrip('|').strip()
+                seeds_text = _text(seeds_li[0]).rstrip('|').strip()
                 try:
                     rank = float(seeds_text)
                 except ValueError:

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -26,6 +26,12 @@ class GayTorrentsSpider(Spider):
     supports_downloads = True
     supports_previews = True
 
+    def _ensure_valid_cookies(self):
+        if not self.session.cookies:
+            return
+        if not self._is_logged_in(self.session.cookies):
+            self.session.cookies.clear()
+
     def get_login_page(self) -> dict[str, Any]:
         session = self.session
         login_url = urljoin(self.host, '/login.php')
@@ -63,12 +69,19 @@ class GayTorrentsSpider(Spider):
 
         session.post(login_url, data=data, allow_redirects=True)
 
-        # vBulletin sets bb_userid (non-zero) on successful login
-        cookies_dict = {c.name: c.value for c in session.cookies}
-        if cookies_dict.get('bb_userid', '0') not in ('0', '', None):
+        # vBulletin sets a *vbb_userid cookie on success (prefix varies per install, e.g. ENvbb_userid)
+        if self._is_logged_in(session.cookies):
             return cookies_to_cookiecloud_items(cookiejar_to_cookies(session.cookies))
 
         raise BizException('登录失败，请检查账号密码')
+
+    @staticmethod
+    def _is_logged_in(cookie_jar) -> bool:
+        """Check for a vBulletin userid cookie with non-zero value (prefix varies per install)."""
+        for c in cookie_jar:
+            if c.name.endswith('vbb_userid') and c.value not in ('0', '', None):
+                return True
+        return False
 
     def get_info(self, num: str, url: str | None = None, include_downloads=False,
                  include_previews=False, include_comments=False):

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -1,0 +1,220 @@
+from datetime import datetime
+from typing import Any
+from urllib.parse import urljoin, urlparse, parse_qs
+
+from lxml import etree
+
+from app.exception import BizException
+from app.schema import VideoDetail, VideoDownload, VideoPreviewItem, VideoPreview
+from app.schema.home import SiteVideo
+from app.utils.cookies import (
+    apply_cookie_header_to_jar,
+    cookiejar_to_cookies,
+    cookies_to_cookiecloud_items,
+    to_cookie_header,
+)
+from app.utils.spider.spider import Session, Spider
+from app.utils.spider.spider_exception import SpiderException
+
+
+class GayTorrentsSpider(Spider):
+    key = 'gaytorrents'
+    name = 'GayTorrents'
+    origin_host = 'https://www.gay-torrents.net'
+    supports_ranking = True
+    supports_login = True
+    supports_downloads = True
+    supports_previews = True
+
+    def get_login_page(self) -> dict[str, Any]:
+        session = self.session
+        login_url = urljoin(self.host, '/login.php')
+
+        response = session.get(login_url)
+        html = etree.HTML(response.content)
+
+        token_els = html.xpath("//input[@name='securitytoken']/@value")
+        authenticity_token = token_els[0] if token_els else ''
+
+        cookie_str = to_cookie_header(cookiejar_to_cookies(session.cookies))
+
+        return {
+            'cookies': cookie_str,
+            'authenticity_token': authenticity_token,
+            'captcha': '',
+        }
+
+    def submit_login(self, cookies: str, authenticity_token: str,
+                     username: str, password: str, captcha: str) -> list[dict]:
+        session = Session()
+        session.headers = self.session.headers.copy()
+
+        apply_cookie_header_to_jar(cookies, session.cookies)
+
+        login_url = urljoin(self.host, '/login.php')
+
+        data = {
+            'do': 'login',
+            'vb_login_username': username,
+            'vb_login_password': password,
+            'securitytoken': authenticity_token,
+            'cookieuser': '1',
+        }
+
+        session.post(login_url, data=data, allow_redirects=True)
+
+        # vBulletin sets bb_userid (non-zero) on successful login
+        cookies_dict = {c.name: c.value for c in session.cookies}
+        if cookies_dict.get('bb_userid', '0') not in ('0', '', None):
+            return cookies_to_cookiecloud_items(cookiejar_to_cookies(session.cookies))
+
+        raise BizException('登录失败，请检查账号密码')
+
+    def get_info(self, num: str, url: str | None = None, include_downloads=False,
+                 include_previews=False, include_comments=False):
+        if url is None:
+            url = urljoin(self.host, f'/torrentdetails.php?torrentid={num}')
+
+        response = self.session.get(url)
+        if not response.ok:
+            raise SpiderException('获取种子详情失败')
+
+        html = etree.HTML(response.content, parser=etree.HTMLParser(encoding='utf-8'))
+
+        # Check we actually got a torrent page (requires login if not logged in)
+        title_el = html.xpath("//h2[@id='file_name']")
+        if not title_el:
+            raise SpiderException('未找到种子详情，请检查登录状态')
+
+        meta = VideoDetail()
+        meta.num = num
+        meta.title = title_el[0].text_content().strip()
+
+        # Parse dt/dd info pairs
+        dt_els = html.xpath("//dl[contains(@class,'userinfo_extra')]/dt")
+        dd_els = html.xpath("//dl[contains(@class,'userinfo_extra')]/dd")
+        info = {dt.text_content().strip(): dd for dt, dd in zip(dt_els, dd_els)}
+
+        if 'Uploaded' in info:
+            try:
+                meta.premiered = datetime.strptime(
+                    info['Uploaded'].text_content().strip(), '%H:%M %d-%b-%Y'
+                ).strftime('%Y-%m-%d')
+            except ValueError:
+                meta.premiered = info['Uploaded'].text_content().strip()
+
+        # Tags
+        tag_els = html.xpath("//dd[@id='taglist']/a")
+        if tag_els:
+            meta.tags = [el.text_content().strip() for el in tag_els if el.text_content().strip()]
+
+        # Category as studio
+        cat_el = html.xpath("//dd[@id='category']//img/@title")
+        if cat_el:
+            meta.studio = cat_el[0]
+
+        # Description / outline
+        desc_el = html.xpath("//div[@id='description']")
+        if desc_el:
+            meta.outline = desc_el[0].text_content().strip()
+
+        # Cover = first full-size preview image
+        img_links = html.xpath("//div[@id='displayimages']/a/@href")
+        if img_links:
+            meta.cover = img_links[0]
+
+        meta.website.append(url)
+
+        if include_previews:
+            meta.previews = self._get_previews(html)
+
+        if include_downloads:
+            meta.downloads = self._get_downloads(html, url)
+
+        return meta
+
+    def _get_previews(self, html):
+        items = []
+        for a_el in html.xpath("//div[@id='displayimages']/a"):
+            full_url = a_el.get('href')
+            thumb_els = a_el.xpath('./img/@src')
+            thumb = thumb_els[0] if thumb_els else full_url
+            if full_url:
+                items.append(VideoPreviewItem(type='image', thumb=thumb, url=full_url))
+        if not items:
+            return []
+        return [VideoPreview(source=self.source_ref(), items=items)]
+
+    def _get_downloads(self, html, page_url: str):
+        token_els = html.xpath("//form[@name='torrentform']//input[@name='securitytoken']/@value")
+        if not token_els:
+            return []
+
+        title_el = html.xpath("//h2[@id='file_name']")
+        name = title_el[0].text_content().strip() if title_el else 'Torrent'
+
+        size_dd = html.xpath("//dl[contains(@class,'userinfo_extra')]/dt[text()='Size']"
+                             "/following-sibling::dd[1]")
+        size = size_dd[0].text_content().strip() if size_dd else None
+
+        download = VideoDownload(source=self.source_ref())
+        download.url = page_url
+        download.name = name
+        download.size = size
+        return [download]
+
+    def get_ranking(self, video_type: str, cycle: str):
+        # video_type is the category path e.g. "porn/Asian" or "nonporn/Drama"
+        url = urljoin(self.host, f'/torrentslist.php?type={video_type}')
+        response = self.session.get(url)
+        if not response.ok:
+            return []
+
+        html = etree.HTML(response.content, parser=etree.HTMLParser(encoding='utf-8'))
+        return self._parse_listing(html)
+
+    def _parse_listing(self, html):
+        result = []
+        rows = html.xpath("//ul[contains(@class,'Torrent-List')]")
+        for row in rows:
+            name_li = row.xpath(".//li[contains(@class,'Torrent-List-Name')]/a[@href]")
+            if not name_li:
+                continue
+
+            a = name_li[0]
+            href = a.get('href', '')
+            title = a.text_content().strip()
+            if not href or not title:
+                continue
+
+            torrent_url = urljoin(self.host, href)
+            qs = parse_qs(urlparse(torrent_url).query)
+            torrent_id = qs.get('torrentid', [href])[0]
+
+            date_li = row.xpath(".//li[contains(@class,'Torrent-List-Date')]")
+            publish_date = None
+            if date_li:
+                date_str = date_li[0].text_content().strip()
+                try:
+                    publish_date = datetime.strptime(date_str, '%H:%M %d-%b-%Y').date()
+                except ValueError:
+                    pass
+
+            seeds_li = row.xpath(".//li[contains(@class,'Torrent-List-Seeds')]")
+            rank = None
+            if seeds_li:
+                seeds_text = seeds_li[0].text_content().strip().rstrip('|').strip()
+                try:
+                    rank = float(seeds_text)
+                except ValueError:
+                    pass
+
+            video = SiteVideo()
+            video.num = torrent_id
+            video.title = title
+            video.url = torrent_url
+            video.publish_date = publish_date
+            video.rank = rank
+            result.append(video)
+
+        return result

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -229,6 +229,10 @@ class GayTorrentsSpider(Spider):
             if not href or not title:
                 continue
 
+            # Skip ad/promo entries
+            if title.startswith('[FFL]'):
+                continue
+
             torrent_url = urljoin(self.host, href)
             qs = parse_qs(urlparse(torrent_url).query)
             torrent_id = qs.get('torrentid', [href])[0]
@@ -251,12 +255,17 @@ class GayTorrentsSpider(Spider):
                 except ValueError:
                     pass
 
+            # Grab the first thumbnail image in the row if present
+            img_srcs = row.xpath(".//img/@src")
+            cover = urljoin(self.host, img_srcs[0]) if img_srcs else None
+
             video = SiteVideo()
             video.num = torrent_id
             video.title = title
             video.url = torrent_url
             video.publish_date = publish_date
             video.rank = rank
+            video.cover = cover
             result.append(video)
 
         return result

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -255,9 +255,8 @@ class GayTorrentsSpider(Spider):
                 except ValueError:
                     pass
 
-            # Grab the first thumbnail image in the row if present
-            img_srcs = row.xpath(".//img/@src")
-            cover = urljoin(self.host, img_srcs[0]) if img_srcs else None
+            # Listing page has no meaningful cover thumbnails; cover is populated on detail fetch
+            cover = None
 
             video = SiteVideo()
             video.num = torrent_id

--- a/app/utils/spider/gaytorrents.py
+++ b/app/utils/spider/gaytorrents.py
@@ -83,8 +83,12 @@ class GayTorrentsSpider(Spider):
     @staticmethod
     def _is_logged_in(cookie_jar) -> bool:
         """Check for a vBulletin userid cookie with non-zero value (prefix varies per install)."""
-        for c in cookie_jar:
-            if c.name.endswith('vbb_userid') and c.value not in ('0', '', None):
+        for name in cookie_jar:
+            if isinstance(name, str):
+                value = cookie_jar.get(name)
+            else:
+                name, value = name.name, name.value
+            if name.endswith('vbb_userid') and value not in ('0', '', None):
                 return True
         return False
 

--- a/app/utils/spider/javdb.py
+++ b/app/utils/spider/javdb.py
@@ -311,7 +311,7 @@ class JavDBSpider(Spider):
             result.append(ranking)
         return result
 
-    def get_ranking(self, video_type: str, cycle: str):
+    def get_ranking(self, video_type: str, cycle: str, **kwargs):
         url = urljoin(self.host, f'/rankings/movies?p={cycle}&t={video_type}')
         response = self.session.get(url)
         html = etree.HTML(response.content, parser=etree.HTMLParser(encoding='utf-8'))

--- a/frontend/src/apis/home.ts
+++ b/frontend/src/apis/home.ts
@@ -47,11 +47,6 @@ export async function getActor(params: GetActorParams): Promise<PagedResponse<Si
     return response.data
 }
 
-export function buildCoverUrl(site_id: number, num: string, url: string): string {
-    const base = (request.defaults.baseURL ?? '').replace(/\/$/, '')
-    return `${base}/home/cover?site_id=${site_id}&num=${encodeURIComponent(num)}&url=${encodeURIComponent(url)}`
-}
-
 export async function downloadTorrent(site_id: number, torrent_id: string): Promise<void> {
     await request.request({
         url: '/home/torrent-download',

--- a/frontend/src/apis/home.ts
+++ b/frontend/src/apis/home.ts
@@ -5,6 +5,7 @@ export interface GetRankingsParams {
     site_id: number;
     video_type: string;
     cycle: string;
+    pages?: number;
 }
 
 export interface GetDetailParams {

--- a/frontend/src/apis/home.ts
+++ b/frontend/src/apis/home.ts
@@ -47,6 +47,15 @@ export async function getActor(params: GetActorParams): Promise<PagedResponse<Si
     return response.data
 }
 
+export async function getCover(site_id: number, num: string, url: string): Promise<string | null> {
+    const response = await request.request({
+        url: '/home/cover',
+        method: 'get',
+        params: {site_id, num, url}
+    })
+    return response.data?.cover ?? null
+}
+
 export async function downloadTorrent(site_id: number, torrent_id: string): Promise<void> {
     await request.request({
         url: '/home/torrent-download',

--- a/frontend/src/apis/home.ts
+++ b/frontend/src/apis/home.ts
@@ -53,7 +53,11 @@ export async function getCover(site_id: number, num: string, url: string): Promi
         method: 'get',
         params: {site_id, num, url}
     })
-    return response.data?.cover ?? null
+    const rawCover: string | null = response.data?.cover ?? null
+    if (!rawCover) return null
+    // Images require site auth cookies — proxy through backend
+    const base = (request.defaults.baseURL ?? '').replace(/\/$/, '')
+    return `${base}/home/proxy-image?site_id=${site_id}&url=${encodeURIComponent(rawCover)}`
 }
 
 export async function downloadTorrent(site_id: number, torrent_id: string): Promise<void> {

--- a/frontend/src/apis/home.ts
+++ b/frontend/src/apis/home.ts
@@ -46,3 +46,11 @@ export async function getActor(params: GetActorParams): Promise<PagedResponse<Si
     })
     return response.data
 }
+
+export async function downloadTorrent(site_id: number, torrent_id: string): Promise<void> {
+    await request.request({
+        url: '/home/torrent-download',
+        method: 'post',
+        params: {site_id, torrent_id}
+    })
+}

--- a/frontend/src/apis/home.ts
+++ b/frontend/src/apis/home.ts
@@ -47,17 +47,9 @@ export async function getActor(params: GetActorParams): Promise<PagedResponse<Si
     return response.data
 }
 
-export async function getCover(site_id: number, num: string, url: string): Promise<string | null> {
-    const response = await request.request({
-        url: '/home/cover',
-        method: 'get',
-        params: {site_id, num, url}
-    })
-    const rawCover: string | null = response.data?.data?.cover ?? null
-    if (!rawCover) return null
-    // Images require site auth cookies — proxy through backend
+export function buildCoverUrl(site_id: number, num: string, url: string): string {
     const base = (request.defaults.baseURL ?? '').replace(/\/$/, '')
-    return `${base}/home/proxy-image?site_id=${site_id}&url=${encodeURIComponent(rawCover)}`
+    return `${base}/home/cover?site_id=${site_id}&num=${encodeURIComponent(num)}&url=${encodeURIComponent(url)}`
 }
 
 export async function downloadTorrent(site_id: number, torrent_id: string): Promise<void> {

--- a/frontend/src/apis/home.ts
+++ b/frontend/src/apis/home.ts
@@ -53,7 +53,7 @@ export async function getCover(site_id: number, num: string, url: string): Promi
         method: 'get',
         params: {site_id, num, url}
     })
-    const rawCover: string | null = response.data?.cover ?? null
+    const rawCover: string | null = response.data?.data?.cover ?? null
     if (!rawCover) return null
     // Images require site auth cookies — proxy through backend
     const base = (request.defaults.baseURL ?? '').replace(/\/$/, '')

--- a/frontend/src/apis/site.ts
+++ b/frontend/src/apis/site.ts
@@ -11,7 +11,7 @@ export interface SiteCapabilities {
 
 export interface SiteItem {
     id: number;
-    spider_key: 'javdb' | 'javbus' | 'jav321' | 'dmm';
+    spider_key: 'javdb' | 'javbus' | 'jav321' | 'dmm' | 'gaytorrents';
     name: string;
     priority: number;
     alternate_host?: string;

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -12,6 +12,7 @@ import {
     UserOutlined,
     VideoCameraOutlined,
     GlobalOutlined,
+    HeartOutlined,
 } from "@ant-design/icons";
 import {createRouter} from "@tanstack/react-router";
 import {routeTree} from "./routeTree.gen.ts";
@@ -32,6 +33,11 @@ export default [
         title: '首页',
         path: '/home',
         icon: (<HomeOutlined/>),
+    },
+    {
+        title: 'GayTorrents',
+        path: '/gaytorrents',
+        icon: (<HeartOutlined/>),
     },
     {
         title: '菜单',

--- a/frontend/src/routes/_index/gaytorrents/-components/item.tsx
+++ b/frontend/src/routes/_index/gaytorrents/-components/item.tsx
@@ -1,0 +1,104 @@
+import React, {useState} from 'react'
+import {Badge, Button, Modal, Space, Tag, theme, Tooltip, Typography} from 'antd'
+import {CalendarOutlined, DownloadOutlined, EyeOutlined, RiseOutlined} from '@ant-design/icons'
+import type {SiteVideo} from '../../../../types/video'
+
+const {useToken} = theme
+const {Text, Paragraph} = Typography
+
+interface TorrentItemProps {
+    item: SiteVideo
+    siteId: number
+    onDownload: (item: SiteVideo) => void
+    onDetail: (item: SiteVideo) => void
+    downloading: boolean
+}
+
+function TorrentItem(props: TorrentItemProps) {
+    const {item, onDownload, onDetail, downloading} = props
+    const {token} = useToken()
+
+    return (
+        <div
+            className="overflow-hidden rounded-lg transition-all hover:shadow-md"
+            style={{
+                background: token.colorBgContainer,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                display: 'flex',
+                flexDirection: 'column',
+                height: '100%',
+            }}
+        >
+            {/* coloured header band as cover placeholder */}
+            <div
+                style={{
+                    background: `linear-gradient(135deg, ${token.colorPrimaryBg} 0%, ${token.colorPrimary}33 100%)`,
+                    padding: '16px 12px 12px',
+                    borderBottom: `1px solid ${token.colorBorderSecondary}`,
+                    minHeight: 64,
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                }}
+            >
+                <Paragraph
+                    ellipsis={{rows: 2, tooltip: item.title}}
+                    style={{
+                        margin: 0,
+                        fontWeight: token.fontWeightStrong,
+                        fontSize: token.fontSize,
+                        color: token.colorText,
+                        lineHeight: 1.4,
+                    }}
+                >
+                    {item.title || item.num}
+                </Paragraph>
+            </div>
+
+            {/* meta row */}
+            <div className="px-3 py-2 flex flex-wrap gap-1" style={{flex: 1}}>
+                {item.rank != null && (
+                    <Tag color="green" icon={<RiseOutlined/>}>
+                        {item.rank} seeds
+                    </Tag>
+                )}
+                {item.publish_date && (
+                    <Tag icon={<CalendarOutlined/>} color="default">
+                        {item.publish_date}
+                    </Tag>
+                )}
+            </div>
+
+            {/* action row */}
+            <div
+                className="px-3 pb-3"
+                style={{display: 'flex', gap: 8}}
+                onClick={e => e.stopPropagation()}
+            >
+                <Tooltip title="查看详情">
+                    <Button
+                        size="small"
+                        icon={<EyeOutlined/>}
+                        style={{flex: 1}}
+                        onClick={() => onDetail(item)}
+                    >
+                        详情
+                    </Button>
+                </Tooltip>
+                <Tooltip title="发送到下载器">
+                    <Button
+                        size="small"
+                        type="primary"
+                        icon={<DownloadOutlined/>}
+                        style={{flex: 1}}
+                        loading={downloading}
+                        onClick={() => onDownload(item)}
+                    >
+                        下载
+                    </Button>
+                </Tooltip>
+            </div>
+        </div>
+    )
+}
+
+export default TorrentItem

--- a/frontend/src/routes/_index/gaytorrents/-components/item.tsx
+++ b/frontend/src/routes/_index/gaytorrents/-components/item.tsx
@@ -1,8 +1,8 @@
-import React, {useEffect, useState} from 'react'
-import {Button, Skeleton, Tag, theme, Tooltip, Typography} from 'antd'
+import React, {useState} from 'react'
+import {Button, Tag, theme, Tooltip, Typography} from 'antd'
 import {CalendarOutlined, DownloadOutlined, EyeOutlined, RiseOutlined} from '@ant-design/icons'
 import type {SiteVideo} from '../../../../types/video'
-import {getCover} from '../../../../apis/home.ts'
+import {buildCoverUrl} from '../../../../apis/home.ts'
 
 const {useToken} = theme
 const {Paragraph} = Typography
@@ -18,18 +18,11 @@ interface TorrentItemProps {
 function TorrentItem(props: TorrentItemProps) {
     const {item, siteId, onDownload, onDetail, downloading} = props
     const {token} = useToken()
-    // undefined = loading, null = no cover, string = proxy url
-    const [cover, setCover] = useState<string | null | undefined>(undefined)
+    const [imgFailed, setImgFailed] = useState(false)
 
-    useEffect(() => {
-        if (!item.num || !item.url) {
-            setCover(null)
-            return
-        }
-        getCover(siteId, item.num, item.url)
-            .then(c => setCover(c))
-            .catch(() => setCover(null))
-    }, [item.num])
+    const coverSrc = item.num && item.url && !imgFailed
+        ? buildCoverUrl(siteId, item.num, item.url)
+        : null
 
     return (
         <div
@@ -42,15 +35,13 @@ function TorrentItem(props: TorrentItemProps) {
                 height: '100%',
             }}
         >
-            {cover === undefined ? (
-                <Skeleton.Image active style={{width: '100%', height: 140, borderRadius: 0, display: 'block'}}/>
-            ) : cover ? (
+            {coverSrc ? (
                 <>
                     <img
-                        src={cover}
+                        src={coverSrc}
                         alt={item.title || item.num}
                         style={{width: '100%', maxHeight: 220, objectFit: 'cover', display: 'block'}}
-                        onError={() => setCover(null)}
+                        onError={() => setImgFailed(true)}
                     />
                     <div style={{padding: '8px 12px 4px'}}>
                         <Paragraph

--- a/frontend/src/routes/_index/gaytorrents/-components/item.tsx
+++ b/frontend/src/routes/_index/gaytorrents/-components/item.tsx
@@ -18,7 +18,7 @@ interface TorrentItemProps {
 function TorrentItem(props: TorrentItemProps) {
     const {item, siteId, onDownload, onDetail, downloading} = props
     const {token} = useToken()
-    // undefined = loading, null = no cover, string = url
+    // undefined = loading, null = no cover, string = proxy url
     const [cover, setCover] = useState<string | null | undefined>(undefined)
 
     useEffect(() => {
@@ -42,43 +42,26 @@ function TorrentItem(props: TorrentItemProps) {
                 height: '100%',
             }}
         >
-            {/* cover area */}
             {cover === undefined ? (
-                /* loading */
-                <Skeleton.Image active style={{width: '100%', height: 160, borderRadius: 0}}/>
+                <Skeleton.Image active style={{width: '100%', height: 140, borderRadius: 0, display: 'block'}}/>
             ) : cover ? (
-                /* image loaded */
                 <>
-                    <div style={{position: 'relative', width: '100%', paddingTop: '56.25%', overflow: 'hidden'}}>
-                        <img
-                            src={cover}
-                            alt={item.title || item.num}
-                            style={{
-                                position: 'absolute',
-                                top: 0, left: 0,
-                                width: '100%', height: '100%',
-                                objectFit: 'cover',
-                            }}
-                            onError={() => setCover(null)}
-                        />
-                    </div>
+                    <img
+                        src={cover}
+                        alt={item.title || item.num}
+                        style={{width: '100%', maxHeight: 220, objectFit: 'cover', display: 'block'}}
+                        onError={() => setCover(null)}
+                    />
                     <div style={{padding: '8px 12px 4px'}}>
                         <Paragraph
                             ellipsis={{rows: 2, tooltip: item.title}}
-                            style={{
-                                margin: 0,
-                                fontWeight: token.fontWeightStrong,
-                                fontSize: token.fontSize,
-                                color: token.colorText,
-                                lineHeight: 1.4,
-                            }}
+                            style={{margin: 0, fontWeight: token.fontWeightStrong, fontSize: token.fontSize, color: token.colorText, lineHeight: 1.4}}
                         >
                             {item.title || item.num}
                         </Paragraph>
                     </div>
                 </>
             ) : (
-                /* no cover fallback */
                 <div
                     style={{
                         background: `linear-gradient(135deg, ${token.colorPrimaryBg} 0%, ${token.colorPrimary}33 100%)`,
@@ -91,58 +74,30 @@ function TorrentItem(props: TorrentItemProps) {
                 >
                     <Paragraph
                         ellipsis={{rows: 2, tooltip: item.title}}
-                        style={{
-                            margin: 0,
-                            fontWeight: token.fontWeightStrong,
-                            fontSize: token.fontSize,
-                            color: token.colorText,
-                            lineHeight: 1.4,
-                        }}
+                        style={{margin: 0, fontWeight: token.fontWeightStrong, fontSize: token.fontSize, color: token.colorText, lineHeight: 1.4}}
                     >
                         {item.title || item.num}
                     </Paragraph>
                 </div>
             )}
 
-            {/* meta row */}
             <div className="px-3 py-2 flex flex-wrap gap-1" style={{flex: 1}}>
                 {item.rank != null && (
-                    <Tag color="green" icon={<RiseOutlined/>}>
-                        {item.rank} seeds
-                    </Tag>
+                    <Tag color="green" icon={<RiseOutlined/>}>{item.rank} seeds</Tag>
                 )}
                 {item.publish_date && (
-                    <Tag icon={<CalendarOutlined/>} color="default">
-                        {item.publish_date}
-                    </Tag>
+                    <Tag icon={<CalendarOutlined/>} color="default">{item.publish_date}</Tag>
                 )}
             </div>
 
-            {/* action row */}
-            <div
-                className="px-3 pb-3"
-                style={{display: 'flex', gap: 8}}
-                onClick={e => e.stopPropagation()}
-            >
+            <div className="px-3 pb-3" style={{display: 'flex', gap: 8}} onClick={e => e.stopPropagation()}>
                 <Tooltip title="查看详情">
-                    <Button
-                        size="small"
-                        icon={<EyeOutlined/>}
-                        style={{flex: 1}}
-                        onClick={() => onDetail(item)}
-                    >
+                    <Button size="small" icon={<EyeOutlined/>} style={{flex: 1}} onClick={() => onDetail(item)}>
                         详情
                     </Button>
                 </Tooltip>
                 <Tooltip title="发送到下载器">
-                    <Button
-                        size="small"
-                        type="primary"
-                        icon={<DownloadOutlined/>}
-                        style={{flex: 1}}
-                        loading={downloading}
-                        onClick={() => onDownload(item)}
-                    >
+                    <Button size="small" type="primary" icon={<DownloadOutlined/>} style={{flex: 1}} loading={downloading} onClick={() => onDownload(item)}>
                         下载
                     </Button>
                 </Tooltip>

--- a/frontend/src/routes/_index/gaytorrents/-components/item.tsx
+++ b/frontend/src/routes/_index/gaytorrents/-components/item.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react'
-import {Badge, Button, Modal, Space, Tag, theme, Tooltip, Typography} from 'antd'
+import React from 'react'
+import {Button, Tag, theme, Tooltip, Typography} from 'antd'
 import {CalendarOutlined, DownloadOutlined, EyeOutlined, RiseOutlined} from '@ant-design/icons'
 import type {SiteVideo} from '../../../../types/video'
 
@@ -29,30 +29,68 @@ function TorrentItem(props: TorrentItemProps) {
                 height: '100%',
             }}
         >
-            {/* coloured header band as cover placeholder */}
-            <div
-                style={{
-                    background: `linear-gradient(135deg, ${token.colorPrimaryBg} 0%, ${token.colorPrimary}33 100%)`,
-                    padding: '16px 12px 12px',
-                    borderBottom: `1px solid ${token.colorBorderSecondary}`,
-                    minHeight: 64,
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                }}
-            >
-                <Paragraph
-                    ellipsis={{rows: 2, tooltip: item.title}}
+            {/* cover image or gradient placeholder */}
+            {item.cover ? (
+                <div style={{position: 'relative', width: '100%', paddingTop: '56.25%', overflow: 'hidden'}}>
+                    <img
+                        src={item.cover}
+                        alt={item.title || item.num}
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            width: '100%',
+                            height: '100%',
+                            objectFit: 'cover',
+                        }}
+                        onError={e => {
+                            (e.currentTarget as HTMLImageElement).style.display = 'none'
+                        }}
+                    />
+                </div>
+            ) : (
+                <div
                     style={{
-                        margin: 0,
-                        fontWeight: token.fontWeightStrong,
-                        fontSize: token.fontSize,
-                        color: token.colorText,
-                        lineHeight: 1.4,
+                        background: `linear-gradient(135deg, ${token.colorPrimaryBg} 0%, ${token.colorPrimary}33 100%)`,
+                        padding: '16px 12px 12px',
+                        borderBottom: `1px solid ${token.colorBorderSecondary}`,
+                        minHeight: 64,
+                        display: 'flex',
+                        alignItems: 'flex-start',
                     }}
                 >
-                    {item.title || item.num}
-                </Paragraph>
-            </div>
+                    <Paragraph
+                        ellipsis={{rows: 2, tooltip: item.title}}
+                        style={{
+                            margin: 0,
+                            fontWeight: token.fontWeightStrong,
+                            fontSize: token.fontSize,
+                            color: token.colorText,
+                            lineHeight: 1.4,
+                        }}
+                    >
+                        {item.title || item.num}
+                    </Paragraph>
+                </div>
+            )}
+
+            {/* title below cover */}
+            {item.cover && (
+                <div style={{padding: '8px 12px 4px'}}>
+                    <Paragraph
+                        ellipsis={{rows: 2, tooltip: item.title}}
+                        style={{
+                            margin: 0,
+                            fontWeight: token.fontWeightStrong,
+                            fontSize: token.fontSize,
+                            color: token.colorText,
+                            lineHeight: 1.4,
+                        }}
+                    >
+                        {item.title || item.num}
+                    </Paragraph>
+                </div>
+            )}
 
             {/* meta row */}
             <div className="px-3 py-2 flex flex-wrap gap-1" style={{flex: 1}}>

--- a/frontend/src/routes/_index/gaytorrents/-components/item.tsx
+++ b/frontend/src/routes/_index/gaytorrents/-components/item.tsx
@@ -1,8 +1,8 @@
-import React, {useState} from 'react'
-import {Button, Tag, theme, Tooltip, Typography} from 'antd'
+import React, {useEffect, useRef, useState} from 'react'
+import {Button, Skeleton, Tag, theme, Tooltip, Typography} from 'antd'
 import {CalendarOutlined, DownloadOutlined, EyeOutlined, RiseOutlined} from '@ant-design/icons'
 import type {SiteVideo} from '../../../../types/video'
-import {buildCoverUrl} from '../../../../apis/home.ts'
+import {request} from '../../../../utils/requests.ts'
 
 const {useToken} = theme
 const {Paragraph} = Typography
@@ -18,11 +18,33 @@ interface TorrentItemProps {
 function TorrentItem(props: TorrentItemProps) {
     const {item, siteId, onDownload, onDetail, downloading} = props
     const {token} = useToken()
-    const [imgFailed, setImgFailed] = useState(false)
+    // undefined = loading, null = no cover, string = blob URL
+    const [coverSrc, setCoverSrc] = useState<string | null | undefined>(undefined)
+    const blobRef = useRef<string | null>(null)
 
-    const coverSrc = item.num && item.url && !imgFailed
-        ? buildCoverUrl(siteId, item.num, item.url)
-        : null
+    useEffect(() => {
+        if (!item.num || !item.url) {
+            setCoverSrc(null)
+            return
+        }
+        request.request({
+            url: '/home/cover',
+            method: 'get',
+            params: {site_id: siteId, num: item.num, url: item.url},
+            responseType: 'blob',
+        }).then(resp => {
+            const url = URL.createObjectURL(resp.data)
+            blobRef.current = url
+            setCoverSrc(url)
+        }).catch(() => setCoverSrc(null))
+
+        return () => {
+            if (blobRef.current) {
+                URL.revokeObjectURL(blobRef.current)
+                blobRef.current = null
+            }
+        }
+    }, [item.num])
 
     return (
         <div
@@ -35,13 +57,15 @@ function TorrentItem(props: TorrentItemProps) {
                 height: '100%',
             }}
         >
-            {coverSrc ? (
+            {coverSrc === undefined ? (
+                <Skeleton.Image active style={{width: '100%', height: 140, borderRadius: 0, display: 'block'}}/>
+            ) : coverSrc ? (
                 <>
                     <img
                         src={coverSrc}
                         alt={item.title || item.num}
                         style={{width: '100%', maxHeight: 220, objectFit: 'cover', display: 'block'}}
-                        onError={() => setImgFailed(true)}
+                        onError={() => setCoverSrc(null)}
                     />
                     <div style={{padding: '8px 12px 4px'}}>
                         <Paragraph

--- a/frontend/src/routes/_index/gaytorrents/-components/item.tsx
+++ b/frontend/src/routes/_index/gaytorrents/-components/item.tsx
@@ -1,7 +1,8 @@
-import React, {useState} from 'react'
-import {Button, Tag, theme, Tooltip, Typography} from 'antd'
+import React, {useEffect, useState} from 'react'
+import {Button, Skeleton, Tag, theme, Tooltip, Typography} from 'antd'
 import {CalendarOutlined, DownloadOutlined, EyeOutlined, RiseOutlined} from '@ant-design/icons'
 import type {SiteVideo} from '../../../../types/video'
+import {getCover} from '../../../../apis/home.ts'
 
 const {useToken} = theme
 const {Paragraph} = Typography
@@ -15,11 +16,20 @@ interface TorrentItemProps {
 }
 
 function TorrentItem(props: TorrentItemProps) {
-    const {item, onDownload, onDetail, downloading} = props
+    const {item, siteId, onDownload, onDetail, downloading} = props
     const {token} = useToken()
-    const [imgError, setImgError] = useState(false)
+    // undefined = loading, null = no cover, string = url
+    const [cover, setCover] = useState<string | null | undefined>(undefined)
 
-    const showCover = !!item.cover && !imgError
+    useEffect(() => {
+        if (!item.num || !item.url) {
+            setCover(null)
+            return
+        }
+        getCover(siteId, item.num, item.url)
+            .then(c => setCover(c))
+            .catch(() => setCover(null))
+    }, [item.num])
 
     return (
         <div
@@ -32,25 +42,43 @@ function TorrentItem(props: TorrentItemProps) {
                 height: '100%',
             }}
         >
-            {/* cover image */}
-            {showCover && (
-                <div style={{position: 'relative', width: '100%', paddingTop: '56.25%', overflow: 'hidden'}}>
-                    <img
-                        src={item.cover!}
-                        alt={item.title || item.num}
-                        style={{
-                            position: 'absolute',
-                            top: 0, left: 0,
-                            width: '100%', height: '100%',
-                            objectFit: 'cover',
-                        }}
-                        onError={() => setImgError(true)}
-                    />
-                </div>
-            )}
-
-            {/* gradient placeholder when no cover / cover failed */}
-            {!showCover && (
+            {/* cover area */}
+            {cover === undefined ? (
+                /* loading */
+                <Skeleton.Image active style={{width: '100%', height: 160, borderRadius: 0}}/>
+            ) : cover ? (
+                /* image loaded */
+                <>
+                    <div style={{position: 'relative', width: '100%', paddingTop: '56.25%', overflow: 'hidden'}}>
+                        <img
+                            src={cover}
+                            alt={item.title || item.num}
+                            style={{
+                                position: 'absolute',
+                                top: 0, left: 0,
+                                width: '100%', height: '100%',
+                                objectFit: 'cover',
+                            }}
+                            onError={() => setCover(null)}
+                        />
+                    </div>
+                    <div style={{padding: '8px 12px 4px'}}>
+                        <Paragraph
+                            ellipsis={{rows: 2, tooltip: item.title}}
+                            style={{
+                                margin: 0,
+                                fontWeight: token.fontWeightStrong,
+                                fontSize: token.fontSize,
+                                color: token.colorText,
+                                lineHeight: 1.4,
+                            }}
+                        >
+                            {item.title || item.num}
+                        </Paragraph>
+                    </div>
+                </>
+            ) : (
+                /* no cover fallback */
                 <div
                     style={{
                         background: `linear-gradient(135deg, ${token.colorPrimaryBg} 0%, ${token.colorPrimary}33 100%)`,
@@ -61,24 +89,6 @@ function TorrentItem(props: TorrentItemProps) {
                         alignItems: 'flex-start',
                     }}
                 >
-                    <Paragraph
-                        ellipsis={{rows: 2, tooltip: item.title}}
-                        style={{
-                            margin: 0,
-                            fontWeight: token.fontWeightStrong,
-                            fontSize: token.fontSize,
-                            color: token.colorText,
-                            lineHeight: 1.4,
-                        }}
-                    >
-                        {item.title || item.num}
-                    </Paragraph>
-                </div>
-            )}
-
-            {/* title below cover (only when cover is showing) */}
-            {showCover && (
-                <div style={{padding: '8px 12px 4px'}}>
                     <Paragraph
                         ellipsis={{rows: 2, tooltip: item.title}}
                         style={{

--- a/frontend/src/routes/_index/gaytorrents/-components/item.tsx
+++ b/frontend/src/routes/_index/gaytorrents/-components/item.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, {useState} from 'react'
 import {Button, Tag, theme, Tooltip, Typography} from 'antd'
 import {CalendarOutlined, DownloadOutlined, EyeOutlined, RiseOutlined} from '@ant-design/icons'
 import type {SiteVideo} from '../../../../types/video'
 
 const {useToken} = theme
-const {Text, Paragraph} = Typography
+const {Paragraph} = Typography
 
 interface TorrentItemProps {
     item: SiteVideo
@@ -17,6 +17,9 @@ interface TorrentItemProps {
 function TorrentItem(props: TorrentItemProps) {
     const {item, onDownload, onDetail, downloading} = props
     const {token} = useToken()
+    const [imgError, setImgError] = useState(false)
+
+    const showCover = !!item.cover && !imgError
 
     return (
         <div
@@ -29,26 +32,25 @@ function TorrentItem(props: TorrentItemProps) {
                 height: '100%',
             }}
         >
-            {/* cover image or gradient placeholder */}
-            {item.cover ? (
+            {/* cover image */}
+            {showCover && (
                 <div style={{position: 'relative', width: '100%', paddingTop: '56.25%', overflow: 'hidden'}}>
                     <img
-                        src={item.cover}
+                        src={item.cover!}
                         alt={item.title || item.num}
                         style={{
                             position: 'absolute',
-                            top: 0,
-                            left: 0,
-                            width: '100%',
-                            height: '100%',
+                            top: 0, left: 0,
+                            width: '100%', height: '100%',
                             objectFit: 'cover',
                         }}
-                        onError={e => {
-                            (e.currentTarget as HTMLImageElement).style.display = 'none'
-                        }}
+                        onError={() => setImgError(true)}
                     />
                 </div>
-            ) : (
+            )}
+
+            {/* gradient placeholder when no cover / cover failed */}
+            {!showCover && (
                 <div
                     style={{
                         background: `linear-gradient(135deg, ${token.colorPrimaryBg} 0%, ${token.colorPrimary}33 100%)`,
@@ -74,8 +76,8 @@ function TorrentItem(props: TorrentItemProps) {
                 </div>
             )}
 
-            {/* title below cover */}
-            {item.cover && (
+            {/* title below cover (only when cover is showing) */}
+            {showCover && (
                 <div style={{padding: '8px 12px 4px'}}>
                     <Paragraph
                         ellipsis={{rows: 2, tooltip: item.title}}

--- a/frontend/src/routes/_index/gaytorrents/index.tsx
+++ b/frontend/src/routes/_index/gaytorrents/index.tsx
@@ -1,14 +1,15 @@
 import React, {useState} from 'react'
-import {Col, Empty, message, Modal, Row, Select, Skeleton, Typography} from 'antd'
-import {HeartOutlined} from '@ant-design/icons'
-import {Await, createFileRoute, redirect, useNavigate} from '@tanstack/react-router'
+import {Button, Col, Empty, message, Modal, Row, Select, Skeleton, Typography} from 'antd'
+import {HeartOutlined, LockOutlined} from '@ant-design/icons'
+import {Await, createFileRoute, redirect, useNavigate, useRouter} from '@tanstack/react-router'
 import * as api from '../../../apis/home.ts'
 import * as siteApi from '../../../apis/site.ts'
 import type {SiteItem} from '../../../apis/site.ts'
 import type {SiteVideo} from '../../../types/video.ts'
 import TorrentItem from './-components/item.tsx'
+import LoginModal from '../site/-components/loginModal.tsx'
 
-const {Title} = Typography
+const {Title, Text} = Typography
 
 // ── categories ────────────────────────────────────────────────────────────────
 const PORN_CATS = [
@@ -39,7 +40,7 @@ interface GTSearch {
     category: string
 }
 
-type GTLoaderData = { siteId: number; items: SiteVideo[] }
+type GTLoaderData = { siteId: number; siteName: string; hasCookies: boolean; items: SiteVideo[] }
 
 export const Route = createFileRoute('/_index/gaytorrents/')({
     component: GayTorrents,
@@ -53,14 +54,23 @@ export const Route = createFileRoute('/_index/gaytorrents/')({
         data: siteApi.getSites().then((sites: SiteItem[]) => {
             const site = sites.find(s => s.spider_key === 'gaytorrents')
             if (!site || !site.status) {
-                return {siteId: 0, items: []} as GTLoaderData
+                return {siteId: 0, siteName: 'GayTorrents', hasCookies: false, items: []} as GTLoaderData
+            }
+            const hasCookies = !!(site.cookies && site.cookies.trim())
+            if (!hasCookies) {
+                return {siteId: site.id, siteName: site.name, hasCookies: false, items: []} as GTLoaderData
             }
             return api.getRankings({
                 site_id: site.id,
                 video_type: deps.category,
                 cycle: '',
-            }).then(items => ({siteId: site.id, items} as GTLoaderData))
-        }).catch(() => ({siteId: 0, items: []} as GTLoaderData))
+            }).then(items => ({
+                siteId: site.id,
+                siteName: site.name,
+                hasCookies: true,
+                items,
+            } as GTLoaderData))
+        }).catch(() => ({siteId: 0, siteName: 'GayTorrents', hasCookies: false, items: []} as GTLoaderData))
     }),
     staleTime: 0,
 })
@@ -70,7 +80,11 @@ function GayTorrents() {
     const {data} = Route.useLoaderData()
     const search = Route.useSearch() as GTSearch
     const navigate = useNavigate()
+    const router = useRouter()
     const [downloadingId, setDownloadingId] = useState<string | null>(null)
+    const [loginOpen, setLoginOpen] = useState(false)
+    const [loginSiteId, setLoginSiteId] = useState<number>(0)
+    const [loginSiteName, setLoginSiteName] = useState<string>('GayTorrents')
 
     const handleCategoryChange = (value: string) => {
         navigate({search: {category: value}})
@@ -101,6 +115,17 @@ function GayTorrents() {
         })
     }
 
+    const openLogin = (siteId: number, siteName: string) => {
+        setLoginSiteId(siteId)
+        setLoginSiteName(siteName)
+        setLoginOpen(true)
+    }
+
+    const handleLoginSuccess = () => {
+        setLoginOpen(false)
+        router.invalidate()
+    }
+
     return (
         <div>
             {/* header */}
@@ -126,13 +151,28 @@ function GayTorrents() {
 
             {/* grid */}
             <Await promise={data} fallback={<Skeleton active/>}>
-                {(payload: GTLoaderData = {siteId: 0, items: []}) => {
+                {(payload: GTLoaderData = {siteId: 0, siteName: 'GayTorrents', hasCookies: false, items: []}) => {
                     if (payload.siteId === 0) {
                         return (
                             <Empty
                                 className="mt-10"
                                 description="GayTorrents 站点未启用，请在「站点」设置中启用并配置 Cookie"
                             />
+                        )
+                    }
+                    if (!payload.hasCookies) {
+                        return (
+                            <div className="mt-10 flex flex-col items-center gap-4">
+                                <LockOutlined style={{fontSize: 48, color: '#aaa'}}/>
+                                <Text type="secondary">需要登录 GayTorrents 才能浏览内容</Text>
+                                <Button
+                                    type="primary"
+                                    icon={<LockOutlined/>}
+                                    onClick={() => openLogin(payload.siteId, payload.siteName)}
+                                >
+                                    立即登录
+                                </Button>
+                            </div>
                         )
                     }
                     return payload.items.length > 0 ? (
@@ -154,6 +194,14 @@ function GayTorrents() {
                     )
                 }}
             </Await>
+
+            <LoginModal
+                siteId={loginSiteId}
+                siteName={loginSiteName}
+                open={loginOpen}
+                onClose={() => setLoginOpen(false)}
+                onSuccess={handleLoginSuccess}
+            />
         </div>
     )
 }

--- a/frontend/src/routes/_index/gaytorrents/index.tsx
+++ b/frontend/src/routes/_index/gaytorrents/index.tsx
@@ -1,0 +1,161 @@
+import React, {useState} from 'react'
+import {Col, Empty, message, Modal, Row, Select, Skeleton, Typography} from 'antd'
+import {HeartOutlined} from '@ant-design/icons'
+import {Await, createFileRoute, redirect, useNavigate} from '@tanstack/react-router'
+import * as api from '../../../apis/home.ts'
+import * as siteApi from '../../../apis/site.ts'
+import type {SiteItem} from '../../../apis/site.ts'
+import type {SiteVideo} from '../../../types/video.ts'
+import TorrentItem from './-components/item.tsx'
+
+const {Title} = Typography
+
+// ── categories ────────────────────────────────────────────────────────────────
+const PORN_CATS = [
+    'Amateur', 'Anal', 'Asian', 'Bareback', 'Bears', 'Bisexual', 'Black-Men',
+    'Chubs', 'Clips', 'Cross-Generation', 'DVD-R', 'Fetish', 'Group-Sex',
+    'HD-Movies', 'Hunks', 'Images', 'Interracial', 'Jocks', 'Latino', 'Mature',
+    'Member', 'MiddleEast', 'Military', 'Muscle', 'Oral-Sex', 'Solo',
+    'Transsexual', 'Twinks', 'Vintage', 'Wrestling',
+]
+const NONPORN_CATS = [
+    'Anime', 'Comedy', 'Comics', 'Coming-Out', 'Documentary', 'Drama', 'DVD-R',
+    'Gay-Movies', 'Misc', 'Short-Film', 'Softcore', 'Thriller', 'TV-Episode',
+]
+
+const CATEGORY_OPTIONS = [
+    {
+        label: 'Porn',
+        options: PORN_CATS.map(c => ({label: c, value: `porn/${c}`})),
+    },
+    {
+        label: 'Non-Porn',
+        options: NONPORN_CATS.map(c => ({label: c, value: `nonporn/${c}`})),
+    },
+]
+
+// ── route ─────────────────────────────────────────────────────────────────────
+interface GTSearch {
+    category: string
+}
+
+type GTLoaderData = { siteId: number; items: SiteVideo[] }
+
+export const Route = createFileRoute('/_index/gaytorrents/')({
+    component: GayTorrents,
+    beforeLoad: ({search}) => {
+        if (!(search as Partial<GTSearch>).category) {
+            throw redirect({search: {category: 'porn/Asian'}})
+        }
+    },
+    loaderDeps: ({search}) => search as GTSearch,
+    loader: async ({deps}) => ({
+        data: siteApi.getSites().then((sites: SiteItem[]) => {
+            const site = sites.find(s => s.spider_key === 'gaytorrents')
+            if (!site || !site.status) {
+                return {siteId: 0, items: []} as GTLoaderData
+            }
+            return api.getRankings({
+                site_id: site.id,
+                video_type: deps.category,
+                cycle: '',
+            }).then(items => ({siteId: site.id, items} as GTLoaderData))
+        }).catch(() => ({siteId: 0, items: []} as GTLoaderData))
+    }),
+    staleTime: 0,
+})
+
+// ── page ──────────────────────────────────────────────────────────────────────
+function GayTorrents() {
+    const {data} = Route.useLoaderData()
+    const search = Route.useSearch() as GTSearch
+    const navigate = useNavigate()
+    const [downloadingId, setDownloadingId] = useState<string | null>(null)
+
+    const handleCategoryChange = (value: string) => {
+        navigate({search: {category: value}})
+    }
+
+    const handleDetail = (item: SiteVideo, siteId: number) => {
+        navigate({to: '/home/detail', search: {site_id: siteId, num: item.num!, url: item.url!}})
+    }
+
+    const handleDownload = (item: SiteVideo, siteId: number) => {
+        Modal.confirm({
+            title: '发送到下载器',
+            content: `确认下载「${item.title || item.num}」？`,
+            okText: '确认',
+            cancelText: '取消',
+            onOk: async () => {
+                if (!item.num) return
+                setDownloadingId(item.num)
+                try {
+                    await api.downloadTorrent(siteId, item.num)
+                    message.success('已发送到下载器')
+                } catch {
+                    message.error('下载失败，请检查下载器设置或登录状态')
+                } finally {
+                    setDownloadingId(null)
+                }
+            }
+        })
+    }
+
+    return (
+        <div>
+            {/* header */}
+            <div className="flex items-center gap-3 mb-4">
+                <HeartOutlined style={{fontSize: 22, color: '#ff4d4f'}}/>
+                <Title level={4} style={{margin: 0}}>GayTorrents</Title>
+            </div>
+
+            {/* category selector */}
+            <div className="mb-4 flex items-center gap-2">
+                <span style={{whiteSpace: 'nowrap', fontWeight: 500}}>分类：</span>
+                <Select
+                    value={search.category}
+                    onChange={handleCategoryChange}
+                    options={CATEGORY_OPTIONS}
+                    style={{width: 200}}
+                    showSearch
+                    filterOption={(input, option) =>
+                        (option?.label as string ?? '').toLowerCase().includes(input.toLowerCase())
+                    }
+                />
+            </div>
+
+            {/* grid */}
+            <Await promise={data} fallback={<Skeleton active/>}>
+                {(payload: GTLoaderData = {siteId: 0, items: []}) => {
+                    if (payload.siteId === 0) {
+                        return (
+                            <Empty
+                                className="mt-10"
+                                description="GayTorrents 站点未启用，请在「站点」设置中启用并配置 Cookie"
+                            />
+                        )
+                    }
+                    return payload.items.length > 0 ? (
+                        <Row gutter={[12, 12]}>
+                            {payload.items.map(item => (
+                                <Col key={item.url} span={24} sm={12} lg={8} xl={6}>
+                                    <TorrentItem
+                                        item={item}
+                                        siteId={payload.siteId}
+                                        downloading={downloadingId === item.num}
+                                        onDetail={i => handleDetail(i, payload.siteId)}
+                                        onDownload={i => handleDownload(i, payload.siteId)}
+                                    />
+                                </Col>
+                            ))}
+                        </Row>
+                    ) : (
+                        <Empty className="mt-10" description="该分类暂无内容"/>
+                    )
+                }}
+            </Await>
+        </div>
+    )
+}
+
+export default GayTorrents

--- a/frontend/src/routes/_index/gaytorrents/index.tsx
+++ b/frontend/src/routes/_index/gaytorrents/index.tsx
@@ -64,6 +64,7 @@ export const Route = createFileRoute('/_index/gaytorrents/')({
                 site_id: site.id,
                 video_type: deps.category,
                 cycle: '',
+                pages: 5,
             }).then(items => ({
                 siteId: site.id,
                 siteName: site.name,

--- a/frontend/src/routes/_index/site/-components/loginModal.tsx
+++ b/frontend/src/routes/_index/site/-components/loginModal.tsx
@@ -21,7 +21,7 @@ function LoginModal(props: LoginModalProps) {
     const {siteId, siteName, open, onClose, onSuccess} = props
 
     const [form] = Form.useForm()
-    const [captchaImg, setCaptchaImg] = useState<string>('')
+    const [captchaImg, setCaptchaImg] = useState<string | null>(null)
     const [loginData, setLoginData] = useState<{cookies: string, authenticity_token: string} | null>(null)
 
     const {run: getLoginPage, loading: gettingLogin} = useRequest(api.getLoginPage, {
@@ -32,7 +32,7 @@ function LoginModal(props: LoginModalProps) {
                 cookies: response.cookies,
                 authenticity_token: response.authenticity_token
             })
-            setCaptchaImg(`data:image/png;base64,${response.captcha}`)
+            setCaptchaImg(response.captcha ? `data:image/png;base64,${response.captcha}` : null)
         },
         onError: (e) => {
             onClose()
@@ -60,7 +60,7 @@ function LoginModal(props: LoginModalProps) {
 
     const handleClose = () => {
         setLoginData(null)
-        setCaptchaImg('')
+        setCaptchaImg(null)
         onClose()
     }
 
@@ -91,25 +91,25 @@ function LoginModal(props: LoginModalProps) {
             destroyOnClose
         >
             <Form form={form} layout={'vertical'} onFinish={handleFinish}>
-                <Form.Item label={'验证码'}>
-                    <Space>
-                        {captchaImg ? (
+                {captchaImg && (
+                    <Form.Item label={'验证码'}>
+                        <Space>
                             <Image src={captchaImg} height={40} preview={false} />
-                        ) : (
-                            <div style={{height: 40, width: 100, background: '#f0f0f0'}} />
-                        )}
-                        <Button size={'small'} onClick={refreshCaptcha} loading={gettingLogin}>换一张</Button>
-                    </Space>
-                </Form.Item>
+                            <Button size={'small'} onClick={refreshCaptcha} loading={gettingLogin}>换一张</Button>
+                        </Space>
+                    </Form.Item>
+                )}
                 <Form.Item name={'username'} label={'账号'} rules={[{required: true}]}>
                     <Input placeholder={'请输入账号'} />
                 </Form.Item>
                 <Form.Item name={'password'} label={'密码'} rules={[{required: true}]}>
                     <Input.Password placeholder={'请输入密码'} />
                 </Form.Item>
-                <Form.Item name={'captcha'} label={'验证码'} rules={[{required: true}]}>
-                    <Input placeholder={'请输入验证码'} />
-                </Form.Item>
+                {captchaImg && (
+                    <Form.Item name={'captcha'} label={'验证码'} rules={[{required: true}]}>
+                        <Input placeholder={'请输入验证码'} />
+                    </Form.Item>
+                )}
                 <div style={{textAlign: 'center'}}>
                     <Button onClick={handleClose} style={{marginRight: 8}}>取消</Button>
                     <Button type={'primary'} htmlType={'submit'} loading={logging}>登录</Button>

--- a/frontend/src/routes/_index/site/-components/loginModal.tsx
+++ b/frontend/src/routes/_index/site/-components/loginModal.tsx
@@ -47,6 +47,7 @@ function LoginModal(props: LoginModalProps) {
             handleClose()
         },
         onError: (e) => {
+            message.error('登录失败，请检查账号密码')
             getLoginPage(siteId)
         }
     })
@@ -74,7 +75,7 @@ function LoginModal(props: LoginModalProps) {
             authenticity_token: loginData.authenticity_token,
             username: values.username,
             password: values.password,
-            captcha: values.captcha
+            captcha: values.captcha ?? ''
         })
     }
 

--- a/frontend/src/types/video.ts
+++ b/frontend/src/types/video.ts
@@ -1,6 +1,6 @@
 export interface SourceRef {
     site_id: number;
-    spider_key: 'javdb' | 'javbus' | 'jav321' | 'dmm';
+    spider_key: 'javdb' | 'javbus' | 'jav321' | 'dmm' | 'gaytorrents';
     site_name: string;
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,4 +6,9 @@ import tailwindcss from "@tailwindcss/vite";
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [tanstackRouter({target: 'react', autoCodeSplitting: false}), tailwindcss(), react()],
+    build: {
+        rollupOptions: {
+            input: './index.html',
+        },
+    },
 })


### PR DESCRIPTION
Implements GayTorrentsSpider for https://www.gay-torrents.net (vBulletin 4.x), supporting cookie-based login, torrent detail scraping, preview images, download tracking, and category-based ranking via torrentslist.php?type={category}.

- app/utils/spider/gaytorrents.py: new spider (login, get_info, get_ranking)
- app/schema/site.py: add GAYTORRENTS to SpiderKey enum
- app/utils/spider/__init__.py: export GayTorrentsSpider
- app/service/spider.py: register in SPIDER_REGISTRY
- alembic/versions/a1b2c3d4e5f6_add_gaytorrents_site.py: insert site row

https://claude.ai/code/session_01QaMZZGDFv5bRcKBXxNLpQy